### PR TITLE
Fix Dijkstra default weight handling

### DIFF
--- a/graph_algos.py
+++ b/graph_algos.py
@@ -67,6 +67,7 @@ def dijkstra(G, s):
     """Performs Dijkstra's algorithm on a graph and returns the order of visited nodes and edges."""
     visited_nodes = []
     visited_edges = []
+    visited = set()
     distances = {node: float("inf") for node in G.nodes}
     distances[s] = 0
     priority_queue = [(0, s)]  # (distance, node)
@@ -74,13 +75,15 @@ def dijkstra(G, s):
     while priority_queue:
         current_distance, current_node = heapq.heappop(priority_queue)
         
-        if current_node in visited_nodes:
+        if current_node in visited:
             continue
 
+        visited.add(current_node)
         visited_nodes.append(current_node)
         
         for neighbor in G.neighbors(current_node):
-            edge_weight = G[current_node][neighbor]["weight"]
+            # default weight to 1 if not specified on the edge
+            edge_weight = G[current_node][neighbor].get("weight", 1)
             new_distance = current_distance + edge_weight
             
             if new_distance < distances[neighbor]:


### PR DESCRIPTION
## Summary
- handle missing edge weights in Dijkstra
- use a visited set for Dijkstra to prevent duplicates

## Testing
- `python -m py_compile *.py`
- `python - <<'PY'
import networkx as nx
from graph_algos import BFS, DFS, dijkstra
G = nx.Graph(); G.add_edges_from([(0,1),(0,2),(1,2),(2,3),(3,4)])
print('BFS', BFS(G,0))
print('DFS', DFS(G,0))
Gw = nx.Graph(); Gw.add_edge(0,1,weight=4); Gw.add_edge(0,2,weight=1); Gw.add_edge(2,1,weight=2); Gw.add_edge(1,3,weight=1); Gw.add_edge(2,3,weight=5)
print('dijkstra', dijkstra(Gw,0))
G2 = nx.Graph(); G2.add_edge(0,1); G2.add_edge(1,2,weight=2)
print(dijkstra(G2,0))
PY

------
https://chatgpt.com/codex/tasks/task_e_68424756e4448333bea66c127be4384c